### PR TITLE
3.7 compatibility

### DIFF
--- a/validity/models/base.py
+++ b/validity/models/base.py
@@ -11,7 +11,7 @@ from netbox.models import (
     ExportTemplatesMixin,
     NetBoxModel,
     RestrictedQuerySet,
-    WebhooksMixin,
+    EventRulesMixin,
 )
 
 from validity.utils import git
@@ -89,7 +89,7 @@ class BaseReadOnlyModel(
     CustomLinksMixin,
     CustomValidationMixin,
     ExportTemplatesMixin,
-    WebhooksMixin,
+    EventRulesMixin,
     models.Model,
 ):
 


### PR DESCRIPTION
https://docs.netbox.dev/en/stable/release-notes/version-3.7/
The netbox.models.features.WebhooksMixin class has been renamed to EventRulesMixin.