### PR TITLE
TypeError FIX

### DIFF
--- a/validity/migrations/0006_datasources.py
+++ b/validity/migrations/0006_datasources.py
@@ -59,7 +59,7 @@ def setup_datasource_cf(apps, schema_editor):
         required=False,
         **{CF_OBJ_TYPE: ContentType.objects.get_for_model(DataSource)}
     )
-    content_types(tenant_cf).set([ContentType.objects.get_for_model(Tenant)])
+    content_types(tenant_cf).set([ContentType.objects.get_for_model(Tenant).pk])
 
 
 def delete_datasource_cf(apps, schema_editor):


### PR DESCRIPTION
I dont know if this bug or not but I got a problem during migrate.
```TypeError: int() argument must be a string, a bytes-like object or a real number, not 'ContentType'```